### PR TITLE
Fix: App Store Connect encryption compliance

### DIFF
--- a/NOICommunity/Info.plist
+++ b/NOICommunity/Info.plist
@@ -62,5 +62,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+    <key>ITSAppUsesNonExemptEncryption</key>
+    <false/>
 </dict>
 </plist>


### PR DESCRIPTION
I added ITSAppUsesNonExemptEncryption key to the app’s Info.plist file in order to skip App Store Connect to walk through an export compliance questionnaire every time a new version of the app is uploaded.

Fixes #20.