### PR TITLE
Add splashscreen

### DIFF
--- a/NOICommunity.xcodeproj/project.pbxproj
+++ b/NOICommunity.xcodeproj/project.pbxproj
@@ -178,6 +178,9 @@
 		31D9C78926FDFCD3001F2DBB /* BaseTabCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTabCoordinator.swift; sourceTree = "<group>"; };
 		31DA4A742705EA110098E395 /* MoreMainViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreMainViewController.swift; sourceTree = "<group>"; };
 		31DA4A752705EA110098E395 /* MoreCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoreCoordinator.swift; sourceTree = "<group>"; };
+		31DA4A782705EBC40098E395 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		31DA4A792705EBC80098E395 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		31DA4A7A2705EBCA0098E395 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -681,6 +684,9 @@
 			isa = PBXVariantGroup;
 			children = (
 				3145D23C26B3F74000F16787 /* Base */,
+				31DA4A782705EBC40098E395 /* en */,
+				31DA4A792705EBC80098E395 /* de */,
+				31DA4A7A2705EBCA0098E395 /* it */,
 			);
 			name = LaunchScreen.storyboard;
 			sourceTree = "<group>";

--- a/NOICommunity/AppDelegate.swift
+++ b/NOICommunity/AppDelegate.swift
@@ -12,7 +12,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
+        configureAppearances()
 
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+}
+
+// MARK: Private APIs
+
+private extension AppDelegate {
+    func configureAppearances() {
         let navBarAppearance = UINavigationBarAppearance()
         navBarAppearance.configureWithOpaqueBackground()
         navBarAppearance.backgroundColor = .backgroundColor
@@ -49,24 +72,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if #available(iOS 15.0, *) {
             UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
         }
-
-        return true
     }
-
-    // MARK: UISceneSession Lifecycle
-
-    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
-        // Called when a new scene session is being created.
-        // Use this method to select a configuration to create the new scene with.
-        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
-    }
-
-    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
-        // Called when the user discards a scene session.
-        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
-        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
-    }
-
-
 }
-

--- a/NOICommunity/Base.lproj/LaunchScreen.storyboard
+++ b/NOICommunity/Base.lproj/LaunchScreen.storyboard
@@ -1,7 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,8 +16,47 @@
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <tabBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HsR-lx-GNq">
+                                <rect key="frame" x="0.0" y="618" width="375" height="49"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <items>
+                                    <tabBarItem title="Today" image="ic_today" id="evZ-Hl-BTG"/>
+                                    <tabBarItem title="Orientate" image="ic_orientate" id="3kn-O4-kON"/>
+                                    <tabBarItem title="Meet" image="ic_meet" id="gfL-c1-9Wj"/>
+                                    <tabBarItem title="Eat" image="ic_eat" id="jcx-D2-Whj"/>
+                                    <tabBarItem title="More" image="ic_more" id="yaZ-Eh-IVF"/>
+                                </items>
+                                <color key="barTintColor" name="background_color"/>
+                            </tabBar>
+                            <navigationBar contentMode="scaleToFill" translucent="NO" largeTitles="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dkp-V3-JPq">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="116"/>
+                                <color key="backgroundColor" name="background_color"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="116" id="cKW-Xk-lLn"/>
+                                </constraints>
+                                <color key="barTintColor" name="background_color"/>
+                                <textAttributes key="titleTextAttributes">
+                                    <color key="textColor" name="primary_color"/>
+                                </textAttributes>
+                                <textAttributes key="largeTitleTextAttributes">
+                                    <color key="textColor" name="primary_color"/>
+                                </textAttributes>
+                                <items>
+                                    <navigationItem largeTitleDisplayMode="always" id="UQz-hR-ZCx"/>
+                                </items>
+                            </navigationBar>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" name="secondary_background_color"/>
+                        <constraints>
+                            <constraint firstItem="dkp-V3-JPq" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="PEL-mu-cpO"/>
+                            <constraint firstItem="HsR-lx-GNq" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="ao7-bY-PbL"/>
+                            <constraint firstAttribute="trailing" secondItem="dkp-V3-JPq" secondAttribute="trailing" id="dQv-pB-ASI"/>
+                            <constraint firstItem="dkp-V3-JPq" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="eEf-j3-PSh"/>
+                            <constraint firstAttribute="bottom" secondItem="HsR-lx-GNq" secondAttribute="bottom" id="maE-s5-kQe"/>
+                            <constraint firstAttribute="trailing" secondItem="HsR-lx-GNq" secondAttribute="trailing" id="olU-iD-z2E"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -22,4 +64,20 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="ic_eat" width="12" height="22"/>
+        <image name="ic_meet" width="27" height="21"/>
+        <image name="ic_more" width="19" height="19"/>
+        <image name="ic_orientate" width="17" height="22"/>
+        <image name="ic_today" width="19" height="22"/>
+        <namedColor name="background_color">
+            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="primary_color">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="secondary_background_color">
+            <color red="0.94509803921568625" green="0.94509803921568625" blue="0.94509803921568625" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/NOICommunity/de.lproj/LaunchScreen.strings
+++ b/NOICommunity/de.lproj/LaunchScreen.strings
@@ -1,0 +1,18 @@
+
+/* Class = "UITabBarItem"; title = "Orientate"; ObjectID = "3kn-O4-kON"; */
+"3kn-O4-kON.title" = "Orientate";
+
+/* Class = "UINavigationItem"; title = "Hey you!"; ObjectID = "UQz-hR-ZCx"; */
+"UQz-hR-ZCx.title" = "Hey you!";
+
+/* Class = "UITabBarItem"; title = "Today"; ObjectID = "evZ-Hl-BTG"; */
+"evZ-Hl-BTG.title" = "Today";
+
+/* Class = "UITabBarItem"; title = "Meet"; ObjectID = "gfL-c1-9Wj"; */
+"gfL-c1-9Wj.title" = "Meet";
+
+/* Class = "UITabBarItem"; title = "Eat"; ObjectID = "jcx-D2-Whj"; */
+"jcx-D2-Whj.title" = "Eat";
+
+/* Class = "UITabBarItem"; title = "More"; ObjectID = "yaZ-Eh-IVF"; */
+"yaZ-Eh-IVF.title" = "More";

--- a/NOICommunity/en.lproj/LaunchScreen.strings
+++ b/NOICommunity/en.lproj/LaunchScreen.strings
@@ -1,0 +1,18 @@
+
+/* Class = "UITabBarItem"; title = "Orientate"; ObjectID = "3kn-O4-kON"; */
+"3kn-O4-kON.title" = "Orientate";
+
+/* Class = "UINavigationItem"; title = "Hey you!"; ObjectID = "UQz-hR-ZCx"; */
+"UQz-hR-ZCx.title" = "Hey you!";
+
+/* Class = "UITabBarItem"; title = "Today"; ObjectID = "evZ-Hl-BTG"; */
+"evZ-Hl-BTG.title" = "Today";
+
+/* Class = "UITabBarItem"; title = "Meet"; ObjectID = "gfL-c1-9Wj"; */
+"gfL-c1-9Wj.title" = "Meet";
+
+/* Class = "UITabBarItem"; title = "Eat"; ObjectID = "jcx-D2-Whj"; */
+"jcx-D2-Whj.title" = "Eat";
+
+/* Class = "UITabBarItem"; title = "More"; ObjectID = "yaZ-Eh-IVF"; */
+"yaZ-Eh-IVF.title" = "More";

--- a/NOICommunity/it.lproj/LaunchScreen.strings
+++ b/NOICommunity/it.lproj/LaunchScreen.strings
@@ -1,0 +1,18 @@
+
+/* Class = "UITabBarItem"; title = "Orientate"; ObjectID = "3kn-O4-kON"; */
+"3kn-O4-kON.title" = "Orientate";
+
+/* Class = "UINavigationItem"; title = "Hey you!"; ObjectID = "UQz-hR-ZCx"; */
+"UQz-hR-ZCx.title" = "Hey you!";
+
+/* Class = "UITabBarItem"; title = "Today"; ObjectID = "evZ-Hl-BTG"; */
+"evZ-Hl-BTG.title" = "Today";
+
+/* Class = "UITabBarItem"; title = "Meet"; ObjectID = "gfL-c1-9Wj"; */
+"gfL-c1-9Wj.title" = "Meet";
+
+/* Class = "UITabBarItem"; title = "Eat"; ObjectID = "jcx-D2-Whj"; */
+"jcx-D2-Whj.title" = "Eat";
+
+/* Class = "UITabBarItem"; title = "More"; ObjectID = "yaZ-Eh-IVF"; */
+"yaZ-Eh-IVF.title" = "More";


### PR DESCRIPTION
From Apple HIG: 

> A launch screen appears instantly when your app starts up and is quickly replaced with the app's first screen, giving the impression that your app is fast and responsive. The launch screen isn’t an opportunity for artistic expression. It’s solely intended to enhance the perception of your app as quick to launch and immediately ready for use. Every app must supply a launch screen.

> Design a launch screen that’s nearly identical to the first screen of your app. If you include elements that look different when the app finishes launching, people can experience an unpleasant flash between the launch screen and the first screen of the app. Also make sure that your launch screen matches the device's current appearance mode; for guidance, see Dark Mode.

Source: https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/launch-screen/ 


Result:
![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-09-29 at 16 51 06](https://user-images.githubusercontent.com/4108197/135293604-e0d2fe8b-325b-40f9-afea-a0dc6d67ccb3.png)

Related to #3 
 