### PR TITLE
Fix crash on add event to calendar

### DIFF
--- a/NOICommunity/Helpers/EventsCalendarManager.swift
+++ b/NOICommunity/Helpers/EventsCalendarManager.swift
@@ -78,12 +78,13 @@ class EventsCalendarManager: NSObject {
             // Auth is not determined
             // We should request access to the calendar
             requestAccess { accessGranted, _ in
-                if accessGranted {
-                    DispatchQueue.main.async(execute: presentationBlock)
-                    completion(.success(()))
-                } else {
-                    // Auth denied, we should display a popup
-                    completion(.failure(CalendarError.calendarAccessDeniedOrRestricted))
+                DispatchQueue.main.async {
+                    if accessGranted {
+                        completion(.success(()))
+                    } else {
+                        // Auth denied, we should display a popup
+                        completion(.failure(CalendarError.calendarAccessDeniedOrRestricted))
+                    }
                 }
             }
         case .denied,


### PR DESCRIPTION
When the calendar access is requested to the user, if she not grant it the app crashes