### PR TITLE
Adds logs to Xcode's Crashlytics run script build step

### DIFF
--- a/NOICommunity.xcodeproj/project.pbxproj
+++ b/NOICommunity.xcodeproj/project.pbxproj
@@ -656,7 +656,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "GOOGLE_PLIST=\"${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app/GoogleService-Info.plist\"\nif [[ \"${CONFIGURATION}\" == \"Release\" ]] && [[ -f ${GOOGLE_PLIST} ]]; then\n    ${BUILD_DIR%Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\nfi\n";
+			shellScript = "if [[ \"${CONFIGURATION}\" == \"Release\" ]]\nthen\n    ${BUILD_DIR%Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\n    echo \"✅ Crashlytics on configuration: ${CONFIGURATION}\"\nelse\n    echo \"❌ Crashlytics on configuration: ${CONFIGURATION}\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
@Piiit it seems that on CI some required step for Crashlytics are not run. I added a few logs that I need in order to fix the original problem.