### PR TITLE
Fixes upload dSYMs to Crashlytics

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,8 +87,7 @@ jobs:
             OTHER_CODE_SIGN_FLAGS="--keychain ~/Library/Keychains/build.keychain" \
             CODE_SIGN_STYLE=Manual \
             PROVISIONING_PROFILE='a5e85966-b44d-4f43-b01d-babf8ce192c3' \
-            CODE_SIGN_IDENTITY="Apple Distribution" \
-          | xcpretty
+            CODE_SIGN_IDENTITY="Apple Distribution"
 
       - name: Export .ipa
         run: |
@@ -97,8 +96,7 @@ jobs:
             -exportOptionsPlist exportOptions.plist \
             -exportPath $PWD/build \
             -allowProvisioningUpdates \
-            -exportArchive \
-          | xcpretty
+            -exportArchive 
 
       - name: Publish the App on TestFlight
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           set -eo pipefail
           xcodebuild clean archive \
+            -configuration Release \
             -scheme NOICommunity \
             -sdk iphoneos \
             -archivePath "$PWD/build/NOICommunity.xcarchive" \


### PR DESCRIPTION
## Premise

Crashes arrives on Crashlytics; but app dSYMs are required in order to be symbolicated.
There is an Xcode script to upload them while release versions of the apps is built, which seems to not be working.

## Fixes

Thus, I

1. Put some logs in the script (see PR #71)
2. Logs are stripped out by xcpretty so I removed its uses from all jobs except test jobs
3. Specified the configuration `Release` into the Xcode archive. This is not really needed since `Release` is the default configuration for archive 
<img width="1291" alt="image" src="https://user-images.githubusercontent.com/4108197/138053364-11a690f8-8b72-449d-a878-979dd1f13c13.png">

