### PR TITLE
Implements "Remove all navigation back button text"

### DIFF
--- a/NOICommunity/EventsFeature/EventsCoordinator.NavigationControllerDelegate.swift
+++ b/NOICommunity/EventsFeature/EventsCoordinator.NavigationControllerDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 // MARK: - EventsCoordinator.EventsNavigationControllerDelegate
 extension EventsCoordinator {
-    class EventsNavigationControllerDelegate: NSObject {
+    class EventsNavigationControllerDelegate: NavigationControllerDelegate {
         
         private weak var navigationController: UINavigationController!
         
@@ -87,7 +87,7 @@ extension EventsCoordinator.EventsNavigationControllerDelegate: UIGestureRecogni
 
 // MARK: UINavigationControllerDelegate
 
-extension EventsCoordinator.EventsNavigationControllerDelegate: UINavigationControllerDelegate {
+extension EventsCoordinator.EventsNavigationControllerDelegate {
     
     func navigationController(
         _ navigationController: UINavigationController,

--- a/NOICommunity/ViewControllers/NavigationController.swift
+++ b/NOICommunity/ViewControllers/NavigationController.swift
@@ -8,7 +8,51 @@
 import UIKit
 
 class NavigationController: UINavigationController {
+
+    private var defaultDelegate: UINavigationControllerDelegate!
+
+    override init(rootViewController: UIViewController) {
+        super.init(rootViewController: rootViewController)
+        configure()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        configure()
+    }
+
+    override init(navigationBarClass: AnyClass?, toolbarClass: AnyClass?) {
+        super.init(
+            navigationBarClass: navigationBarClass,
+            toolbarClass: toolbarClass
+        )
+        configure()
+    }
+
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        configure()
+    }
+
     override var childForStatusBarStyle: UIViewController? {
         visibleViewController
+    }
+}
+
+private extension NavigationController {
+    func configure() {
+        defaultDelegate = NavigationControllerDelegate()
+        delegate = defaultDelegate
+    }
+}
+
+class NavigationControllerDelegate: NSObject, UINavigationControllerDelegate {
+    func navigationController(
+        _ navigationController: UINavigationController,
+        willShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        // Removes any label from navigation back button
+        viewController.navigationItem.backButtonDisplayMode = .minimal
     }
 }


### PR DESCRIPTION
Forces all navigation items' back button display mode to minimal; i.e. without any label/text.

Implements #51

![Simulator Screen Shot - iPhone SE (2nd generation) - 2021-11-18 at 08 48 34](https://user-images.githubusercontent.com/4108197/142373777-e1ac65af-fd08-450c-bc21-183e01d8b6e5.png)
 