### PR TITLE
Implement automatic logout on OAuth authentication errors

### DIFF
--- a/NOICommunity/SceneDelegate.swift
+++ b/NOICommunity/SceneDelegate.swift
@@ -66,7 +66,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     endSessionURI: AuthConstant.endSessionURI
                 ),
                 context: self,
-                tokenStorage: tokenStorage
+                tokenStorage: tokenStorage,
+                onInvalidAuth: {
+                    NotificationCenter.default.post(
+                        name: logoutNotification,
+                        object: nil
+                    )
+                }
             ),
 			eventShortClient: EventShortClientImplementation(
 				baseURL: EventsFeatureConstants.clientBaseURL,

--- a/NOICommunityLib/Sources/AuthClient/Interface.swift
+++ b/NOICommunityLib/Sources/AuthClient/Interface.swift
@@ -62,6 +62,9 @@ extension UserInfo: Hashable {
 public enum AuthError: Error, Hashable {
     case userCanceledAuthorizationFlow
     case OAuthTokenInvalidGrant
+    case OAuthTokenInvalidScope
+    case OAuthTokenInvalidClient
+    case OAuthTokenInvalidRequest
 }
 
 // MARK: - AuthClient


### PR DESCRIPTION
# OAuth Error Handling Improvements

## Summary

Implements automatic logout when OAuth authentication errors occur, bringing iOS feature parity with Android. The changes extend error handling to cover all OAuth error types that indicate invalid authentication (`invalid_grant`, `invalid_scope`, `invalid_client`, `invalid_request`), not just `invalid_grant`.

**Note**: This feature was already implemented in the Android version and was missing from the iOS app version.

## Problem

When OAuth errors occur (such as `invalid_grant`), the authentication state becomes invalid, but the iOS app was not automatically logging out users. This created platform inconsistency and could lead to poor UX, security concerns, and inconsistent app state.

## Solution

1. Automatically logs out users when OAuth errors indicate invalid authentication
2. Handles all OAuth error types that indicate invalid authentication
3. Provides consistent error handling across all authentication operations