### PR TITLE
OIDC Registration Flow Migration

### DIFF
--- a/NOICommunity/AuthFeature/AuthConstants.swift
+++ b/NOICommunity/AuthFeature/AuthConstants.swift
@@ -25,21 +25,6 @@ enum AuthConstant {
 		NOIOAuth2BaseURL
 	}()
 
-	static let signupURL: URL = {
-		var urlComponents = URLComponents(
-			url: NOIOAuth2BaseURL,
-			resolvingAgainstBaseURL: false
-		)!
-		urlComponents.path += "protocol/openid-connect/registrations"
-		urlComponents.queryItems = [
-			URLQueryItem(name: "client_id", value: clientID),
-			URLQueryItem(name: "redirect_uri", value: "https://noi.bz.it"),
-			URLQueryItem(name: "response_type", value: "code"),
-			URLQueryItem(name: "scope", value: "openid"),
-		]
-		return urlComponents.url!
-	}()
-
 	static let clientID = "community-app"
 
 	static let redirectURI = URL(string: "noi-community://oauth2redirect/login-callback")!

--- a/NOICommunity/AuthFeature/AuthCoordinator.swift
+++ b/NOICommunity/AuthFeature/AuthCoordinator.swift
@@ -48,7 +48,7 @@ final class AuthCoordinator: BaseNavigationCoordinator {
 private extension AuthCoordinator {
     
     func goToLogin() {
-        authClient.accessToken()
+        authClient.accessToken(.default)
             .sink { [weak self] completion in
                 guard let self = self
                 else { return }
@@ -69,8 +69,24 @@ private extension AuthCoordinator {
     }
     
     func goToSignUp() {
-        let safariVC = SFSafariViewController(url: AuthConstant.signupURL)
-        navigationController.present(safariVC, animated: true)
+		authClient.accessToken(.registration)
+			.sink { [weak self] completion in
+				guard let self = self
+				else { return }
+
+				switch completion {
+				case .finished:
+					break
+				case .failure(let error):
+					self.handleAuthError(error)
+				}
+			} receiveValue: { [weak self] accessToken in
+				guard let self = self
+				else { return }
+
+				self.didFinishHandler(self)
+			}
+			.store(in: &subscriptions)
     }
 
     func goToAppPrivacyPage() {

--- a/NOICommunity/AuthFeature/LoadUserInfoViewModel.swift
+++ b/NOICommunity/AuthFeature/LoadUserInfoViewModel.swift
@@ -53,7 +53,7 @@ final class LoadUserInfoViewModel {
     
     func fetchVerifiedUserInfo() {
         let userInfoPublisher = authClient.userInfo()
-        let peoplePublisher = authClient.accessToken()
+        let peoplePublisher = authClient.accessToken(.default)
             .flatMap { [peopleClient] accessToken in
                 peopleClient.people(accessToken)
             }

--- a/NOICommunity/AuthFeature/LoadUserInfoViewModel.swift
+++ b/NOICommunity/AuthFeature/LoadUserInfoViewModel.swift
@@ -70,7 +70,8 @@ final class LoadUserInfoViewModel {
 
                             return person.hasEmail(userEmail) || 
                             userEmail == "noi.community.app.test@opendatahub.com" ||
-                            userEmail.hasSuffix("@dimension.it")
+                            userEmail.hasSuffix("@dimension.it") ||
+							userEmail.hasSuffix("@afliant.com")
                         }
                     }
                     .setFailureType(to: Error.self)

--- a/NOICommunity/Info.plist
+++ b/NOICommunity/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/NOICommunity/MeetFeature/View Models/PeopleViewModel.swift
+++ b/NOICommunity/MeetFeature/View Models/PeopleViewModel.swift
@@ -71,7 +71,7 @@ final class PeopleViewModel {
                 .setFailureType(to: Error.self)
                 .eraseToAnyPublisher()
         } else {
-            let authenticatedCompaniesPublisher = authClient.accessToken()
+            let authenticatedCompaniesPublisher = authClient.accessToken(.default)
                 .flatMap { [peopleClient] accessToken in
                     peopleClient.companies(accessToken)
                 }
@@ -86,7 +86,7 @@ final class PeopleViewModel {
                 .eraseToAnyPublisher()
         }
         
-        let peoplePublisher = authClient.accessToken()
+        let peoplePublisher = authClient.accessToken(.default)
             .flatMap { [peopleClient] accessToken in
                 peopleClient.people(accessToken)
             }

--- a/NOICommunityLib/Sources/AuthClient/Interface.swift
+++ b/NOICommunityLib/Sources/AuthClient/Interface.swift
@@ -67,18 +67,26 @@ public enum AuthError: Error, Hashable {
     case OAuthTokenInvalidRequest
 }
 
+// MARK: - AuthFoo
+
+public enum AuthAccessTokenMode: Int {
+	case `default`
+	case registration
+}
+
+
 // MARK: - AuthClient
 
 public struct AuthClient {
     
-    public var accessToken: () -> AnyPublisher<String, Error>
-    
+	public var accessToken: (_ mode: AuthAccessTokenMode) -> AnyPublisher<String, Error>
+
     public var userInfo: () -> AnyPublisher<UserInfo, Error>
     
     public var endSession: () -> AnyPublisher<Void, Error>
     
     public init(
-        accessToken: @escaping () -> (AnyPublisher<String, Error>),
+        accessToken: @escaping (_ mode: AuthAccessTokenMode) -> (AnyPublisher<String, Error>),
         userInfo: @escaping() -> AnyPublisher<UserInfo, Error>,
         endSession: @escaping () -> (AnyPublisher<Void, Error>)
     ) {

--- a/NOICommunityLib/Sources/AuthClientLive/Live.swift
+++ b/NOICommunityLib/Sources/AuthClientLive/Live.swift
@@ -86,10 +86,11 @@ public extension AuthClient {
         var authSession: OIDExternalUserAgentSession?
         
         return Self(
-            accessToken: {
+            accessToken: { mode in
                 performActionWithFreshToken(authState: authState)
                     .catch { (error: Error) -> AnyPublisher<String, Error> in
                         startSSO(
+							mode: mode,
                             config: client,
                             from: context.presentationContext()
                         )
@@ -222,13 +223,21 @@ private extension AuthClient {
     }
     
     static func startSSO(
+		mode: AuthAccessTokenMode,
         configuration: OIDServiceConfiguration,
         clientID: String,
         redirectURI: URL,
         from presentationContext: UIViewController
     ) -> (OIDExternalUserAgentSession, AnyPublisher<OIDAuthState, Error>) {
         let subject = PassthroughSubject<OIDAuthState, Error>()
-        
+
+		let additionalParameters: [String: String]
+		switch mode {
+		case .default:
+			additionalParameters = ["prompt": "login"]
+		case .registration:
+			additionalParameters = ["prompt": "create"]
+		}
         let request = OIDAuthorizationRequest(
             configuration: configuration,
             clientId: clientID,
@@ -236,7 +245,7 @@ private extension AuthClient {
             scopes: [OIDScopeOpenID, OIDScopeProfile, "roles"],
             redirectURL: redirectURI,
             responseType: OIDResponseTypeCode,
-            additionalParameters: ["prompt": "login"]
+            additionalParameters: additionalParameters
         )
         
         let session = OIDAuthState.authState(
@@ -257,12 +266,14 @@ private extension AuthClient {
     }
     
     static func startSSO(
+		mode: AuthAccessTokenMode,
         config: OpenIDConfiguration,
         from presentationContext: UIViewController
     ) -> AnyPublisher<(OIDExternalUserAgentSession, OIDAuthState), Error> {
         discoverConfiguration(of: config.issuer)
             .flatMap { (discoveredConfig: OIDServiceConfiguration) -> AnyPublisher<(OIDExternalUserAgentSession, OIDAuthState), Error> in
                 let (newSession, ssoPublisher) = startSSO(
+					mode: mode,
                     configuration: discoveredConfig,
                     clientID: config.clientID,
                     redirectURI: config.redirectURI,

--- a/NOICommunityTests/Info.plist
+++ b/NOICommunityTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>

--- a/NOICommunityUITests/Info.plist
+++ b/NOICommunityUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 </dict>


### PR DESCRIPTION
This PR migrates the user registration flow from a custom URL-based approach to the standard OIDC (OpenID Connect) authentication flow using the `prompt=create` parameter. This change unifies the login and registration flows to use the same OIDC authentication mechanism, improving security and maintainability.
